### PR TITLE
Operator overloads

### DIFF
--- a/include/talta.hpp
+++ b/include/talta.hpp
@@ -303,6 +303,10 @@ namespace Talta {
         return point;
       };
       inline void pushFromGlobal(std::shared_ptr<Ceetah::InsertionPoint> point) {
+        while (source.insertionPoint->node->nodeType() != Ceetah::AST::NodeType::RootNode) {
+          source.insertionPoint = source.insertionPoint->parent;
+        }
+        source.insertionPoint->moveForward();
         source.insertionPoint = point;
       };
 

--- a/include/talta.hpp
+++ b/include/talta.hpp
@@ -294,6 +294,17 @@ namespace Talta {
           )
         );
       };
+      inline std::shared_ptr<Ceetah::InsertionPoint> popToGlobal() {
+        auto point = source.insertionPoint;
+        while (source.insertionPoint->node->nodeType() != Ceetah::AST::NodeType::RootNode) {
+          source.insertionPoint = source.insertionPoint->parent;
+        }
+        source.insertionPoint->moveBackward();
+        return point;
+      };
+      inline void pushFromGlobal(std::shared_ptr<Ceetah::InsertionPoint> point) {
+        source.insertionPoint = point;
+      };
 
       // <coroutine-helpers>
       auto bind(const CoroutineMemberFunction function) -> Coroutine::FunctionType;

--- a/include/talta.hpp
+++ b/include/talta.hpp
@@ -229,6 +229,20 @@ namespace Talta {
           canTempify = det->fromCaster || det->toCaster;
           canCopy = !canTempify;
         }
+        if (type == ANT::BinaryOperation) {
+          auto op = std::dynamic_pointer_cast<AAST::BinaryOperation>(node);
+          auto det = std::dynamic_pointer_cast<DH::BinaryOperation>(info);
+
+          canCopy = !det->operatorMethod;
+          canTempify = !canCopy;
+        }
+        if (type == ANT::UnaryOperation) {
+          auto op = std::dynamic_pointer_cast<AAST::UnaryOperation>(node);
+          auto det = std::dynamic_pointer_cast<DH::UnaryOperation>(info);
+
+          canCopy = !det->operatorMethod;
+          canTempify = !canCopy;
+        }
         return std::make_pair(
           (
             type != ANT::ClassInstantiationExpression &&
@@ -339,6 +353,7 @@ namespace Talta {
       Coroutine& transpileBitfieldDefinitionNode(Coroutine& co);
       Coroutine& transpileLambdaExpression(Coroutine& co);
       Coroutine& transpileSpecialFetchExpression(Coroutine& co);
+      Coroutine& transpileClassOperatorDefinitionStatement(Coroutine& co);
       // </transpilation-methods>
 
       static const ALTACORE_MAP<AltaCore::AST::NodeType, CoroutineMemberFunction> transpilationMethods;

--- a/src/talta.cpp
+++ b/src/talta.cpp
@@ -1658,6 +1658,10 @@ std::shared_ptr<Ceetah::AST::Expression> Talta::CTranspiler::cast(std::shared_pt
         copy = false;
       }
     } else if (component.type == CCT::From) {
+      auto state = popToGlobal();
+      hoist(component.method, false);
+      pushFromGlobal(state);
+
       ref();
       result = source.createFunctionCall(source.createFetch(mangleName(component.method.get())), {
         result,
@@ -1666,6 +1670,10 @@ std::shared_ptr<Ceetah::AST::Expression> Talta::CTranspiler::cast(std::shared_pt
       additionalCopyInfo = std::make_pair(false, true);
       currentType = std::make_shared<DET::Type>(component.method->parentScope.lock()->parentClass.lock());
     } else if (component.type == CCT::To) {
+      auto state = popToGlobal();
+      hoist(component.method, false);
+      pushFromGlobal(state);
+
       auto to = component.method;
       auto classType = std::make_shared<DET::Type>(component.method->parentScope.lock()->parentClass.lock());
       if (additionalCopyInfo.second) {

--- a/src/talta.cpp
+++ b/src/talta.cpp
@@ -321,11 +321,11 @@ std::string Talta::mangleName(AltaCore::DET::ScopeItem* item, bool fullName) {
 
   if (nodeType == NodeType::Function) {
     auto func = dynamic_cast<DET::Function*>(item);
-    itemName = escapeName(func->name);
+    isLiteral = func->isLiteral;
+    itemName = isLiteral ? func->name : escapeName(func->name);
     for (auto arg: func->genericArguments) {
       itemName += "_2_" + mangleType(arg.get());
     }
-    isLiteral = func->isLiteral;
 
     if (!isLiteral) {
       itemName = escapeName(itemName);
@@ -338,27 +338,27 @@ std::string Talta::mangleName(AltaCore::DET::ScopeItem* item, bool fullName) {
     }
   } else if (nodeType == NodeType::Variable) {
     auto var = dynamic_cast<DET::Variable*>(item);
-    itemName = escapeName(var->name);
+    isLiteral = isLiteral || var->isLiteral;
+    itemName = isLiteral ? var->name : escapeName(var->name);
     if (auto ps = var->parentScope.lock()) {
       if (auto pc = ps->parentClass.lock()) {
         isLiteral = pc->isLiteral;
       }
     }
-    isLiteral = isLiteral || var->isLiteral;
     if (var->isVariable) {
       mangled += "_Alta_array_";
     }
   } else if (nodeType == NodeType::Namespace) {
     auto ns = dynamic_cast<DET::Namespace*>(item);
-    itemName = ns->name;
     isLiteral = false;
+    itemName = isLiteral ? ns->name : escapeName(ns->name);
   } else if (nodeType == NodeType::Class) {
     auto klass = dynamic_cast<DET::Class*>(item);
-    itemName = klass->name;
+    isLiteral = klass->isLiteral;
+    itemName = isLiteral ? klass->name : escapeName(klass->name);
     for (auto arg: klass->genericArguments) {
       itemName += "_2_" + mangleType(arg.get());
     }
-    isLiteral = klass->isLiteral;
   }
 
   if (!isLiteral && fullName) {


### PR DESCRIPTION
Refer to alta-lang/alta-core#14 for the corresponding PR in AltaCore.

This PR adds transpilation for operator methods and usage, as well as various bug fixes. Among other things, this PR also makes sure that variadic arguments are pushed onto the stack.